### PR TITLE
Updating TcellExTRECT to allow cram support and bug fix so that function medianexoncoverage doesnt error when all exons removed

### DIFF
--- a/R/getCovFromBam.R
+++ b/R/getCovFromBam.R
@@ -1,13 +1,14 @@
 #' Function to create TCRA coverage file from bams
 #'
-#' @param bamPath Path to bam file
-#' @param outPath Path to output directory
-#' @param vdj.seg Location of TCRA file
+#' @param bamPath    Path to bam file
+#' @param outPath    Path to output directory
+#' @param vdj.seg    Location of TCRA file
+#' @param formatFile Extension of the alignment file, either cram or bam. Default: bam
 #' @name getCovFromBam
 #' @export
 
 
-getCovFromBam <- function(bamPath, outPath, vdj.seg){
+getCovFromBam <- function(bamPath, outPath, vdj.seg, formatFile = "bam"){
   # Requires samtools to be installed and working!
   if(length(bamPath) != 1){
     stop('Please only input one bam file at a time')
@@ -17,17 +18,23 @@ getCovFromBam <- function(bamPath, outPath, vdj.seg){
     stop('Can not find bam file')
   }
 
+  if(!formatFile %in% c("bam", "cram")){
+    stop('formatFile needs to be one of "cram" or "bam"')
+  }
+
+
   vdj.start <- vdj.seg[vdj.seg$segName == 'all','start']
   vdj.end <- vdj.seg[vdj.seg$segName == 'all','end']
 
-  cov.name <- gsub('.bam','',basename(bamPath))
+  cov.name <- gsub(paste0('.',formatFile),'',basename(bamPath))
   cov.output.files <- paste0(outPath,cov.name, '_TCRA.txt')
 
-  # Check does bai file exist
-  bai.path <- paste0(bamPath,'.bai')
-  bai.path2 <- paste0(gsub('bam$','',bamPath),'bai')
-  if(!(file.exists(bai.path) | file.exists(bai.path2))){
-    stop('No index bai file found for bam, please index first before proceeding')
+  # Check and index file exist
+  index.extension <- ifelse(formatFile == "bam", ".bai", ".crai")
+  index.path <- paste0(bamPath,index.extension)
+  index.path2 <- paste0(gsub('bam$','',bamPath),index.extension)
+  if(!(file.exists(index.path ) | file.exists(index.path2))){
+    stop('No index file found for cram or bam, please index first before proceeding')
   }
 
   # Check if bam has chr or not before

--- a/R/medianExonCoverage.R
+++ b/R/medianExonCoverage.R
@@ -25,12 +25,17 @@ medianExonCoverage <- function(vdj.region.df, exons.selected, median.k = 50, med
   median.values.exons <- sapply(vdj.region.df.filt.exons.median,
                                 function(x) median(x$reads, na.rm = TRUE))
   exon.remove <- which(median.values.exons < median.thresh | is.na(median.values.exons))
-  if(length(exon.remove) > 0){
+  if(length(exon.remove) > 0) {
     vdj.region.df.filt.exons.median <- vdj.region.df.filt.exons.median[-exon.remove]
   }
   vdj.region.df.filt.exons.median <- Reduce(rbind, vdj.region.df.filt.exons.median)
 
-  # Get rid of any repeated rows that might exist - in theory I don't think they will
-  vdj.region.df.filt.exons.median <- dplyr::distinct(vdj.region.df.filt.exons.median)
-  return(list(vdj.region.df.filt.exons.median, exon.remove))
+  if (is.null(vdj.region.df.filt.exons.median)) {
+    vdj.region.df.filt.exons.median <- tibble::tibble(pos = numeric(), reads = numeric())
+    return(list(vdj.region.df.filt.exons.median, exon.remove))
+  } else {
+    # Get rid of any repeated rows that might exist - in theory I don't think they will
+    vdj.region.df.filt.exons.median <- dplyr::distinct(vdj.region.df.filt.exons.median)
+    return(list(vdj.region.df.filt.exons.median, exon.remove))
+  }
 }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Running T cell ExTRECT on your data is both fast and easy!
 library(TcellExTRECT)
 ```
 
-First take an aligned bam file (hg38 or hg19) of your choice
+First take an aligned bam/cram file (hg38 or hg19) of your choice
 
 ```r
 example_bam <- '/path/to/file.bam'


### PR DESCRIPTION
The distinct function throws an error when all exons are removed due to low coverage. I've added a quick check whether the object is null. In cases where all exons are removed, it will return an empty tibble; otherwise it will return the object as before.